### PR TITLE
Fixes Table of Contents and back-to-TOC links in notebook

### DIFF
--- a/Python Code Samples From the Slide.ipynb
+++ b/Python Code Samples From the Slide.ipynb
@@ -36,60 +36,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "<a id=\"toc\"></a>\n",
     "## Table of Content\n",
     "\n",
-    "[1. First Interaction](#firstinteraction)<br>\n",
-    "[2. Numbers](#numbers)<br>\n",
-    "[3. Assignment](#assignment)<br>\n",
-    "[4. Floating Point](#floatingpoint)<br>\n",
-    "[5. Complex Numbers](#complexnumbers)<br>\n",
-    "[6. Bit Operations](#bitoperations)<br>\n",
-    "[7. String](#string)<br>\n",
-    "[8. List](#list)<br>\n",
-    "[9. Booleans](#booleans)<br>\n",
-    "[10. While](#while)<br>\n",
-    "[11. If](#if)<br>\n",
-    "[12. For](#for)<br>\n",
-    "[13. Range Function](#rangefunction)<br>\n",
-    "[14. For-/While-loops: break, continue, else](#forwhile)<br>\n",
-    "[15. The Empty Expression](#empty)<br>\n",
-    "[16. The None Value](#none)<br>\n",
-    "[17. Procedures](#procedures)<br>\n",
-    "[18. On Parameters](#onparameters)<br>\n",
-    "[19. Global Variables](#globalvariables)<br>\n",
-    "[20. Return Values](#returnvalues)<br>\n",
-    "[21. Doc String](#docstring)<br>\n",
-    "[22. Anonymous Functions](#anonymousfunctions)<br>\n",
-    "[23. More List Operations](#morelistoperations)<br>\n",
-    "[24. Higher-Order Functions on Lists](#higherorderfunctionsonlists)<br>\n",
-    "[25. List Comprehensions](#listcomprehensions)<br>\n",
-    "[26. Deletion](#deletion)<br> \n",
-    "[27. Tuples](#tuples)<br> \n",
-    "[28. Sets](#sets)<br> \n",
-    "[29. dictionaries](#dictionaries)<br> \n",
-    "[30. Deletion And More](#deletionmore)<br> \n",
-    "[31. Mutable](#mutable)<br> \n",
-    "[32. Loop Techniques](#looptechniques)<br> \n",
-    "[33. Comparison Sequences](#comparisonsequences)<br> \n",
-    "[34. Equality And Identity](#equalityandidentity)<br> \n",
-    "[35. Copy And Deepcopy](#copyanddeepcopy)<br> \n",
-    "[36. More On Recursion](#moreonrecursion)<br> \n",
-    "[37. Modules](#modules)<br> \n",
-    "[38. Output Formatting](#outputformatting)<br> \n",
-    "[39. Exceptions](#exceptions)<br> \n",
-    "[40. Iteratorsin Detail](#iteratorsindetail)<br> \n",
-    "[41. Generators](#generators)<br> \n"
+    "1. [First Interaction](#our-first-python-interaction)\n",
+    "2. [Numbers](#numbers)\n",
+    "3. [Assignment](#assignment)\n",
+    "4. [Floating Point](#floating-point)\n",
+    "5. [Complex Numbers](#complex-numbers)\n",
+    "6. [Bit Operations](#bit-operations)\n",
+    "7. [String](#string)\n",
+    "8. [List](#list)\n",
+    "9. [Booleans](#booleans)\n",
+    "10. [While](#while)\n",
+    "11. [If](#if)\n",
+    "12. [For](#for)\n",
+    "13. [Range Function](#range-function)\n",
+    "14. [For-/While-loops: `break`, `continue`, `else`](#for-while-loops-break-continue-else)\n",
+    "15. [The Empty Expression](#the-empty-expression)\n",
+    "16. [The None Value](#the-none-value)\n",
+    "17. [Procedures](#procedures)\n",
+    "18. [On Parameters](#on-parameters)\n",
+    "19. [Global Variables](#global-variables)\n",
+    "20. [Return Values](#return-values)\n",
+    "21. [Doc String](#doc-strings)\n",
+    "22. [Anonymous Functions](#anonymous-functions)\n",
+    "23. [More List Operations](#more-list-operations)\n",
+    "24. [Higher-Order Functions on Lists](#higher-order-functions-on-lists)\n",
+    "25. [List Comprehensions](#list-comprehensions)\n",
+    "26. [Deletion](#deletion)\n",
+    "27. [Tuples](#tuples)\n",
+    "28. [Sets](#sets)\n",
+    "29. [dictionaries](#dictionaries)\n",
+    "30. [Deletion And More](#deletion--more)\n",
+    "31. [Mutable](#mutable-vs-immutable-types)\n",
+    "32. [Loop Techniques](#loop-techniques)\n",
+    "33. [Comparison Sequences](#comparison-of-sequences-and-other-types)\n",
+    "34. [Equality And Identity](#equality-and-identity-in-python)\n",
+    "35. [Copy And Deepcopy](#copy-and-deepcopy)\n",
+    "36. [More On Recursion](#more-on-recursion)\n",
+    "37. [Modules](#modules)\n",
+    "38. [Output Formatting](#output-formatting)\n",
+    "39. [Exceptions](#exceptions)\n",
+    "40. [Iteratorsin Detail](#iterators-in-detail)\n",
+    "41. [Generators](#generators)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"firstinteraction\"></a>\n",
     "# Our first Python interaction\n",
-    "[Back to TOC](#toc)<br>"
+    "\n",
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -197,9 +195,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"numbers\"></a>\n",
     "# Numbers\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -867,10 +864,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"assignment\"></a>\n",
-    "\n",
     "# Assignment\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -986,9 +981,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"floatingpoint\"></a>\n",
     "# Floating point\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -1321,9 +1315,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"complexnumbers\"></a>\n",
     "# Complex Numbers\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -1443,9 +1436,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"bitoperations\"></a>\n",
     "# Bit operations\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -1767,9 +1759,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"string\"></a>\n",
     "# String\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "\n"
    ]
   },
@@ -2201,9 +2192,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"list\"></a>\n",
     "# List\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
+    "\n",
     "Lists are *mutable arrays*"
    ]
   },
@@ -2989,9 +2980,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"booleans\"></a>\n",
     "# Booleans\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -3277,9 +3267,8 @@
     "collapsed": true
    },
    "source": [
-    "<a id=\"while\"></a>\n",
     "# While\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "Print all Fibonacci numbers up to 100"
    ]
@@ -3318,7 +3307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comparison operators: == < > <= >= !="
+    "Comparison operators: `==`, `<`, `>`, `<=`, `>=,` `!=`"
    ]
   },
   {
@@ -3355,10 +3344,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"if\"></a>\n",
     "# If\n",
-    "[Back to TOC](#toc)<br>\n",
-    "**elif** instead of else if to avoid further indentations."
+    "[Back to TOC ↑](#table-of-content)<br>\n",
+    "\n",
+    "**`elif`** instead of else if to avoid further indentations."
    ]
   },
   {
@@ -3392,9 +3381,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"for\"></a>\n",
     "# For\n",
-    "[Back to TOC](#toc)<br>\n"
+    "[Back to TOC ↑](#table-of-content)<br>\n"
    ]
   },
   {
@@ -3496,9 +3484,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"rangefunction\"></a>\n",
     "# Range function\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -3913,9 +3900,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"forwhile\"></a>\n",
-    "# For-/While-loops: break, continue, else\n",
-    "[Back to TOC](#toc)<br>\n",
+    "# For-/While-loops: `break`, `continue`, `else`\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "- **`break`** (as in C), terminates the enclosing loop immediately.\n",
     "- **`continue`** (as in C), jumps to the next iteration of the enclosing loop.\n",
@@ -3957,9 +3943,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"empty\"></a>\n",
     "# The empty expression\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "The **`pass`** statement in Python is used when a statement is required syntactically but you do not want any command or code to execute."
    ]
   },
@@ -3977,9 +3962,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"none\"></a>\n",
     "# The None value\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "None is handy for implementing partial functions. Suppose you want to implement division division; what to do with divide-by-zero?\n",
     "\n",
     "You could raise an exception . . . or just return a `None` value."
@@ -4041,9 +4025,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"procedures\"></a>\n",
     "# Procedures\n",
-    "[Back to TOC](#toc)\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "Procedures are defined using the key word def.\n",
     "\n",
@@ -4187,9 +4170,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"onparameters\"></a>\n",
     "# On parameters\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "Assignment to parameters of a function are local."
    ]
   },
@@ -4240,9 +4222,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"globalvariables\"></a>\n",
     "# Global Variables\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "The access to a global variable has to be explicitly declared."
    ]
   },
@@ -4273,9 +4254,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"returnvalues\"></a>\n",
     "# Return values\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -4320,9 +4300,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"docstring\"></a>\n",
     "# Doc-strings\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -4372,9 +4351,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"anonymousfunctions\"></a>\n",
     "# Anonymous Functions\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -4548,9 +4526,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"morelistoperations\"></a>\n",
     "# More list operations\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -4838,9 +4815,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"higherorderfunctionsonlists\"></a>\n",
     "# Higher-order functions on Lists\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)<br>"
    ]
   },
   {
@@ -5043,9 +5019,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"listcomprehensions\"></a>\n",
     "# List comprehensions\n",
-    "[Back to TOC](#toc)<br>\n",
+    "\n",
+    "[Back to TOC ↑](#table-of-content)\n",
+    "\n",
     "- More readable notation for combinations of map and filter.\n",
     "- Motivated by set comprehensions in mathematical notation.\n",
     "- `[ e(x,y) for x in seq1 if p(x) for y in seq2 ]`"
@@ -5155,9 +5132,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"deletion\"></a>\n",
     "# Deletion\n",
-    "[Back to TOC](#toc)<br>"
+    "\n",
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -5233,9 +5210,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"tuples\"></a>\n",
     "# Tuples\n",
-    "[Back to TOC](#toc)<br>\n",
+    "\n",
+    "[Back to TOC ↑](#table-of-content)\n",
+    "\n",
     "They work exactly like lists, except that tuples can’t be changed in place (they’re immutable) and are usually written as a series of items in parentheses, not square brackets. Although they don’t support as many methods, tuples share most of their properties with lists."
    ]
   },
@@ -5397,9 +5375,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"sets\"></a>\n",
     "# Sets\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -5600,9 +5577,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"dictionaries\"></a>\n",
     "# Dictionaries\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "Dictionaries are finite maps, hash maps, associative arrays. They represent unordered sets of (key, value) pairs."
    ]
@@ -5733,9 +5709,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"deletionmore\"></a>\n",
     "# Deletion + more\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -5851,9 +5826,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"mutable\"></a>\n",
     "# Mutable vs Immutable Types\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "\n",
     "Python distinguishes between mutable and immutable types. Mutable types have methods to change the value; immutable types don’t.\n",
     "https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types"
@@ -6315,10 +6289,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"looptechniques\"></a>\n",
     "# Loop Techniques\n",
-    "[Back to TOC](#toc)<br>\n",
-    "\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "\n",
     "- Here are some useful patterns involving loops over dictionaries.\n",
     "- Simultaneous iteration over both keys and elements of a dictionary:"
@@ -6458,9 +6430,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"comparisonsequences\"></a>\n",
     "# Comparison of sequences and other types\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -6586,9 +6557,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"equalityandidentity\"></a>\n",
     "#  Equality and identity in Python\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
+    "\n",
     "Equality is `x == y`. Seems simple—but it isn’t. Equality is just a\n",
     "method; we can program ‘equality’ to do anything at all:"
    ]
@@ -6852,9 +6823,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"copyanddeepcopy\"></a>\n",
     "# Copy and Deepcopy\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)<br>\n",
     "\n",
     "**`copy.copy`** makes a copy with links to original structure;\n",
     "\n",
@@ -7016,9 +6986,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"moreonrecursion\"></a>\n",
     "# More on Recursion\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "<font color=\"red\">You are expected to know</font>\n",
     "- Recursion is when a program calls itself. See the notes on Ocaml.\n",
@@ -7309,9 +7278,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"modules\"></a>\n",
     "# Modules\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -7339,9 +7307,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"outputformatting\"></a>\n",
     "# Output Formatting\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -7602,9 +7569,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"exceptions\"></a>\n",
     "# Exceptions\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "- Exceptions can be caught using a `try...except...` expression.\n",
     "- It is possible to catch several exceptions in one except block: `except (RuntimeError, TypeError, NameError): pass`"
@@ -7919,10 +7885,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"iteratorsindetail\"></a>\n",
-    "\n",
     "# Iterators in detail\n",
-    "[Back to TOC](#toc)<br>"
+    "[Back to TOC ↑](#table-of-content)"
    ]
   },
   {
@@ -7962,10 +7926,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"generators\"></a>\n",
     "# Generators\n",
     "\n",
-    "[Back to TOC](#toc)<br>\n",
+    "[Back to TOC ↑](#table-of-content)\n",
     "\n",
     "A method, containing a **`yield`** expression, is a **generator**.\n",
     "\n",


### PR DESCRIPTION
Fixes the hyperlinks which uses the Markdown-styled hyperlinks instead of HTML `<a>` tags.

Makes it easier to navigate the notebook and fixes the issues with the links when using it in Google Colab.

- Fixes the links to the headers (i.e. `#floating-point`)
- Fixes the link to the Table of Contents (rather than using the `<a>` tag)